### PR TITLE
Add classes for OpenGL task management

### DIFF
--- a/GlRenderer/Task/GlTaskQueue.cs
+++ b/GlRenderer/Task/GlTaskQueue.cs
@@ -1,0 +1,76 @@
+﻿using SharpGL;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+
+namespace ShaderBaker.GlRenderer.Task
+{
+
+//TODO it may not be a bad idea for this class to accept the C# equivalent of a Java Executor as a constructor parameter. This would allow it to manage task execution internally.
+
+/// <summary>
+/// An object for storing tasks that need executed on an OpenGL thread.
+/// </summary>
+public sealed class GlTaskQueue
+{
+    private readonly ConcurrentQueue<IGlTask> tasks = new ConcurrentQueue<IGlTask>();
+
+    /// <summary>
+    /// Submits a task for execution
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Submitting a task does not guarantee that it will be executed right away, or
+    /// even in the near future - only that it will be executed eventually.
+    /// </para>
+    /// <para>
+    /// Though this class is called a queue, submitted tasks are not guaranteed to
+    /// execute in the order that they are submitted. If one task has a dependency
+    /// on another, the depending task should not be submitted until the dependent
+    /// task has completed. It is safe to submit a task from another task, so this
+    /// is a simple option for handling that use-case.
+    /// </para>
+    /// </remarks>
+    /// <param name="task">The task to execute</param>
+    public void SubmitTask(IGlTask task)
+    {
+        Debug.Assert(task != null, "Cannot submit a null task");
+        tasks.Enqueue(task);
+    }
+
+    /// <summary>
+    /// Executes all of the currently enqueued tasks
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Read the short description again, carefully. This method executes only
+    /// the <i>currently enqueued</i> tasks. If more tasks are enqueued while
+    /// this method is running, they will not get executed this time around. This
+    /// method is intended to be called repeatedly in the rendering loop.
+    /// </para>
+    /// <para>
+    /// This method should only be called from a thread containing an OpenGL
+    /// context on which it is appropriate to execute tasks submitted to this
+    /// queue, and it should not be called from multiple threads at the same
+    /// time. Managing OpenGL across multiple threads can get hairy, so if this
+    /// method is called from different threads, it should be done with caution.
+    /// </para>
+    /// </remarks>
+    /// <param name="gl"></param>
+    public void ExecuteTasks(OpenGL gl)
+    {
+        // Bound the number of tasks to run to the current size of the queue.
+        // This prevents this method from running forever in the case that
+        // one of the tasks submits more tasks. It also puts an upper bound
+        // on the time this method runs, since tasks can be submitted as
+        // this method is running.
+        int tasksToRun = tasks.Count;
+        for (int i = 0; i < tasksToRun; ++i)
+        {
+            IGlTask task;
+            tasks.TryDequeue(out task);
+            task.Execute(gl);
+        }
+    }
+}
+
+}

--- a/GlRenderer/Task/IGlTask.cs
+++ b/GlRenderer/Task/IGlTask.cs
@@ -1,0 +1,20 @@
+﻿using SharpGL;
+
+namespace ShaderBaker.GlRenderer.Task
+{
+
+/// <summary>
+/// A task to be submitted to <see cref="GlTaskQueue"/> for
+/// exeuction on an OpenGL thread.
+/// </summary>
+/// <remarks>
+/// Since these tasks are likely to be shared across multiple
+/// threads, it is recommended that these tasks be made immutable
+/// to guarantee their thread-safety.
+/// </remarks>
+public interface IGlTask
+{
+    void Execute(OpenGL gl);
+}
+
+}

--- a/GlRenderer/Task/SingletonGlTask.cs
+++ b/GlRenderer/Task/SingletonGlTask.cs
@@ -1,0 +1,108 @@
+﻿using SharpGL;
+using System;
+using System.Diagnostics;
+using System.Threading;
+
+namespace ShaderBaker.GlRenderer.Task
+{
+
+/// <summary>
+/// A task that can be placed into a <see cref="GlTaskQueue"/> at most once.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This class is useful for tasks whose inputs are updated frequently, but
+/// only need to be executed once, with the latest set of parameters. For
+/// example, the source code for a shader changes frequently if the user is
+/// typing it in a GUI, but only the latest code that they typed matters.
+/// Changing the source requires a shader to be recompiled, which will also
+/// trigger any programs with the shader attached to link again. This class
+/// could be used to prevent clients from overloading the queue with copious
+/// amounts of compile and link tasks.
+/// </para>
+/// <para>
+/// This kind of task has a little more overhead than a standard task, so
+/// it should not be used for operations that will run quickly anyways.
+/// However, in the case of expensive operations, it can help improve
+/// overall throughput.
+/// </para>
+/// </remarks>
+public sealed class SingletonGlTask
+{
+    private readonly Impl impl;
+    
+    /// <summary>
+    /// Create a new <c>SingletonGlTask</c> that confines tasks to the
+    /// given queue.
+    /// </summary>
+    /// <param name="taskQueue">The queue to which tasks will be confined</param>
+    public SingletonGlTask(GlTaskQueue taskQueue)
+    {
+        if (taskQueue == null)
+        {
+            throw new NullReferenceException("taskQueue");
+        }
+
+        this.impl = new Impl(taskQueue);
+    }
+   
+    /// <summary>
+    /// Submit the given task to the task queue.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// If this task already has a task in the queue, the currently enqueued
+    /// task will be replaced with the given one.
+    /// </para>
+    /// <para>
+    /// Since tasks are most likely run from a separate thread than that in
+    /// which they are created, it is recommended that the provided task be
+    /// immutable, which will guarantee its thread-safety. Using a mutable
+    /// task object will most likely be a race condition between the tasks
+    /// queue and the task itself.
+    /// </para>
+    /// </remarks>
+    /// <param name="task">The task to submit</param>
+    public void Submit(IGlTask task)
+    {
+        impl.Submit(task);
+    }
+
+    // A private class is used to hide the IGlTask interface from outside this
+    // class. This ensures that nobody but this class can submit it to the queue.
+    private struct Impl : IGlTask
+    {
+        private readonly GlTaskQueue taskQueue;
+
+        private IGlTask wrappedTask;
+            
+        public Impl(GlTaskQueue taskQueue)
+        {
+            this.taskQueue = taskQueue;
+            this.wrappedTask = null;
+        }
+
+        public void Submit(IGlTask task)
+        {
+            // Use an atomic operation to ensure that the task is submitted exactly once.
+            // Set the task to a value, and if no task was there already, we have the
+            // go-ahead to submit the task.
+            bool shouldSubmit = Interlocked.Exchange(ref wrappedTask, task) == null;
+            if (shouldSubmit)
+            {
+                taskQueue.SubmitTask(this);
+            }
+        }
+
+        public void Execute(OpenGL gl)
+        {
+            IGlTask task = Interlocked.Exchange(ref wrappedTask, null);
+            Debug.Assert(
+                task != null,
+                "Wrapped task should not be null during SingletonTask execution");
+            task.Execute(gl);
+        }
+    }
+}
+
+}

--- a/ShaderBaker.csproj
+++ b/ShaderBaker.csproj
@@ -68,8 +68,11 @@
       <SubType>Designer</SubType>
     </ApplicationDefinition>
     <Compile Include="DataAccess\ShaderResource.cs" />
+    <Compile Include="GlRenderer\Task\GlTaskQueue.cs" />
     <Compile Include="GlRenderer\NullShaderInputs.cs" />
     <Compile Include="GlRenderer\ShaderCompiler.cs" />
+    <Compile Include="GlRenderer\Task\IGlTask.cs" />
+    <Compile Include="GlRenderer\Task\SingletonGlTask.cs" />
     <Compile Include="GlUtilities\GlErrorUtilities.cs" />
     <Compile Include="GlUtilities\ShaderUtilities.cs" />
     <Compile Include="GlUtilities\ProgramUtilities.cs" />


### PR DESCRIPTION
I am anticipating that code will frequently want to execute some OpenGL task, but may not be on a valid thread to do so, or may not have access to an OpenGL context. The [GlTaskQueue](https://github.com/dboone/shader-baker/blob/gl-task-manager/GlRenderer/Task/GlTaskQueue.cs) class is designed to help get those tasks executing on the correct thread.

Additionally, to improve performance, it may not make sense to submit tasks to the queue more than once. The [SingletonGlTask](https://github.com/dboone/shader-baker/blob/gl-task-manager/GlRenderer/Task/SingletonGlTask.cs) provides a means of enforcing this constraint.
