### PR TITLE
Add project for SVG to ICO file conversions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bin/
 obj/
 packages/
 *.suo
+*.csproj.user

--- a/ShaderBaker.sln
+++ b/ShaderBaker.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShaderBaker", "ShaderBaker.csproj", "{28323196-FC47-4021-94B6-CCF5CADB7AA7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Svg2Ico", "Svg2Ico\Svg2Ico.csproj", "{5E208507-18AA-4520-92FE-F8799DAB76A8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{28323196-FC47-4021-94B6-CCF5CADB7AA7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{28323196-FC47-4021-94B6-CCF5CADB7AA7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{28323196-FC47-4021-94B6-CCF5CADB7AA7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5E208507-18AA-4520-92FE-F8799DAB76A8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5E208507-18AA-4520-92FE-F8799DAB76A8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5E208507-18AA-4520-92FE-F8799DAB76A8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5E208507-18AA-4520-92FE-F8799DAB76A8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Svg2Ico/App.config
+++ b/Svg2Ico/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+    </startup>
+</configuration>

--- a/Svg2Ico/ArgumentParser.cs
+++ b/Svg2Ico/ArgumentParser.cs
@@ -1,0 +1,373 @@
+﻿using Mono.Options;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Text;
+
+namespace SvgToIco
+{
+
+struct IcoResolution
+{
+    public readonly int Width;
+
+    public byte IcoHeaderWidth
+    {
+        get
+        {
+            return (byte) Width;
+        }
+    }
+
+    public readonly int Height;
+
+    public byte IcoHeaderHeight
+    {
+        get
+        {
+            return (byte) Height;
+        }
+    }
+    
+    public IcoResolution(IcoSize size)
+    {
+        Width = size.Value;
+        Height = size.Value;
+    }
+    
+    public IcoResolution(IcoSize width, IcoSize height)
+    {
+        Width = width.Value;
+        Height = height.Value;
+    }
+}
+
+class IcoSize
+{
+    public readonly int Value;
+
+    public static bool TryGetInstance(int value, out IcoSize size)
+    {
+        if (value < 0 || value > 256)
+        {
+            size = null;
+            return false;
+        } else
+        {
+            size = new IcoSize(value);
+            return true;
+        }
+    }
+
+    private IcoSize(int value)
+    {
+        Value = value;
+    }
+}
+
+class Svg2IcoArguments
+{
+    public static bool TryParse(string[] arguments, out Svg2IcoArguments parsedArguments)
+    {
+        var showHelp = false;
+        var recurse = false;
+        var outdir = "";
+        var resolutionsStr = new List<string>();
+        var unprocessedArgs = new OptionSet()
+            .Add("h|help", value => showHelp = true)
+            .Add("r|recurse", value => recurse = true)
+            .Add<string>("o=|outdir=", value => outdir = value)
+            .Add<string>("s=|size=", value => resolutionsStr.Add(value))
+            .Parse(arguments);
+
+        // The option parser doesn't distinguish between unrecognized options, and
+        // options after a '--', so we have to do this ourselves. *sigh*
+        for (int i = 0; i < arguments.Length; ++i)
+        {
+            if (arguments[i] == "--")
+            {
+                int numTrailingArgs = arguments.Length - i - 1;
+                int numInvalidArgs = unprocessedArgs.Count - numTrailingArgs;
+                if (numInvalidArgs > 0)
+                {
+                    Console.Write("Unknown options:");
+                    for (int j = 0; j < numInvalidArgs; ++j)
+                    {
+                        Console.Write(' ' + unprocessedArgs[j]);
+                    }
+                    Console.WriteLine("\n\n    Use the --help option to show available options.\n");
+                    parsedArguments = null;
+                    return false;
+                }
+                break;
+            }
+        }
+
+        var inputPaths = new HashSet<string>(unprocessedArgs);
+
+        var invalidResolutions = new List<string>();
+        var allResolutions = new HashSet<IcoResolution>();
+        foreach (var sizeStr in resolutionsStr)
+        {
+            IEnumerable<IcoResolution> resolutions;
+            if (SizeSpecParser.TryParse(sizeStr, out resolutions))
+            {
+                allResolutions.UnionWith(resolutions);
+            } else
+            {
+                invalidResolutions.Add(sizeStr);
+            }
+        }
+
+        if (invalidResolutions.Count > 0)
+        {
+            foreach (var invalidResolution in invalidResolutions)
+            {
+                Console.WriteLine("Invalid resolution: " + invalidResolution);
+            }
+            parsedArguments = null;
+            return false;
+        } else
+        {
+            parsedArguments = new Svg2IcoArguments(
+                showHelp,
+                outdir,
+                recurse,
+                allResolutions,
+                inputPaths);
+            return true;
+        }
+    }
+
+    public readonly bool ShowHelp;
+
+    private readonly string outputDirectory;
+    
+    public bool HasOutputDirectory
+    {
+        get
+        {
+            return outputDirectory.Length > 0;
+        }
+    }
+
+    public string OutputDirectory
+    {
+        get
+        {
+            if (!HasOutputDirectory)
+            {
+                throw new InvalidOperationException("No output directory is present");
+            }
+            return outputDirectory;
+        }
+    }
+
+    public readonly bool Recurse;
+    
+    public readonly IReadOnlyCollection<IcoResolution> Resolutions;
+
+    public readonly IReadOnlyCollection<string> InputPaths;
+
+    public Svg2IcoArguments(
+        bool showHelp,
+        string outputDirectory,
+        bool recurse,
+        ISet<IcoResolution> resolutions,
+        ISet<string> inputPaths)
+    {
+        ShowHelp = showHelp;
+        this.outputDirectory = outputDirectory;
+        Recurse = recurse;
+        Resolutions = new ReadOnlyCollection<IcoResolution>(
+            new List<IcoResolution>(resolutions));
+        InputPaths = new ReadOnlyCollection<string>(
+            new List<string>(inputPaths));
+    }
+}
+
+static class SizeSpecParser
+{
+    private enum TokenType
+    {
+        EndOfInput,
+        Error,
+        DimensionSeparator,
+        Number,
+        RangeSeparator
+    }
+
+    public static bool TryParse(
+        string sizeStr, out IEnumerable<IcoResolution> resolutions)
+    {
+        LexerEnumerator lexerEnumerator = new LexerEnumerator(sizeStr);
+        var token1 = lexerEnumerator.NextToken();
+        var token2 = lexerEnumerator.NextToken();
+        var token3 = lexerEnumerator.NextToken();
+        if (token1.Item1 == TokenType.Number
+            && token2.Item1 == TokenType.EndOfInput
+            && token3.Item1 == TokenType.EndOfInput)
+        {
+            int size;
+            IcoSize icoSize;
+            if (int.TryParse(token1.Item2, out size)
+                && IcoSize.TryGetInstance(size, out icoSize))
+            {
+                resolutions = new IcoResolution[] { new IcoResolution(icoSize) };
+                return true;
+            }
+        } else if (token1.Item1 == TokenType.Number
+            && token2.Item1 == TokenType.DimensionSeparator
+            && token3.Item1 == TokenType.Number)
+        {
+            int width;
+            int height;
+            IcoSize icoWidth;
+            IcoSize icoHeight;
+            if (int.TryParse(token1.Item2, out width)
+                && int.TryParse(token3.Item2, out height)
+                && IcoSize.TryGetInstance(width, out icoWidth)
+                && IcoSize.TryGetInstance(height, out icoHeight))
+            {
+                resolutions = new IcoResolution[] { new IcoResolution(icoWidth, icoHeight) };
+                return true;
+            }
+        } else if (token1.Item1 == TokenType.Number
+            && token2.Item1 == TokenType.RangeSeparator
+            && token3.Item1 == TokenType.Number)
+        {
+            uint start;
+            uint end;
+            if (uint.TryParse(token1.Item2, out start)
+                && uint.TryParse(token3.Item2, out end)
+                && start >= 0
+                && end <= 8
+                && end >= start)
+            {
+                int[] sizeLookupTable =
+                {
+                    1, 2, 4, 8, 16, 32, 64, 128, 256
+                };
+
+                var result = new List<IcoResolution>();
+                for (uint i = start; i <= end; ++i)
+                {
+                    IcoSize icoSize;
+                    // No need to do check the return value of GetInstance.
+                    // Values are guaranteed to be in the right range anyways.
+                    IcoSize.TryGetInstance(sizeLookupTable[i], out icoSize);
+                    Debug.Assert(icoSize != null, "Expected icoSize to be set");
+                    result.Add(new IcoResolution(icoSize));
+                }
+                resolutions = result;
+                return true;
+            }
+        }
+
+        resolutions = null;
+        return false;
+    }
+
+    private class LexerEnumerator
+    {
+        private enum State
+        {
+            Start,
+            NewToken,
+            Number,
+            OneDot,
+            Error
+        }
+
+        private readonly CharEnumerator inputEnumerator;
+
+        private State state;
+        
+        private readonly StringBuilder tokenBuilder = new StringBuilder();
+
+        private bool endOfInput;
+
+        public LexerEnumerator(string input)
+        {
+            inputEnumerator = input.GetEnumerator();
+            state = State.Start;
+            tokenBuilder = new StringBuilder();
+            endOfInput = false;
+        }
+
+        private void moveNextCharacter()
+        {
+            endOfInput = !inputEnumerator.MoveNext();
+        }
+
+        public Tuple<TokenType, string> NextToken()
+        {
+            while (true)
+            {
+                switch (state)
+                {
+                    case State.Start:
+                        moveNextCharacter();
+                        if (endOfInput)
+                        {
+                            state = State.Error;
+                        } else
+                        {
+                            state = State.NewToken;
+                        }
+                        break;
+                    case State.NewToken:
+                        if (endOfInput)
+                        {
+                            return Tuple.Create(TokenType.EndOfInput, "");
+                        }
+
+                        var c = inputEnumerator.Current;
+                        if (char.IsDigit(c))
+                        {
+                            state = State.Number;
+                        } else if (c == 'x')
+                        {
+                            moveNextCharacter();
+                            return Tuple.Create(TokenType.DimensionSeparator, "x");
+                        } else if (c == '.')
+                        {
+                            moveNextCharacter();
+                            state = State.OneDot;
+                        }
+                        break;
+                    case State.Number:
+                        if (endOfInput || !char.IsDigit(inputEnumerator.Current))
+                        {
+                            var number = tokenBuilder.ToString();
+                            tokenBuilder.Clear();
+                            state = State.NewToken;
+                            return Tuple.Create(TokenType.Number, number);
+                        } else
+                        {
+                            tokenBuilder.Append(inputEnumerator.Current);
+                            moveNextCharacter();
+                        }
+
+                        break;
+                    case State.OneDot:
+                        if (endOfInput || inputEnumerator.Current != '.')
+                        {
+                            state = State.Error;
+                        } else
+                        {
+                            moveNextCharacter();
+                            state = State.NewToken;
+                            return Tuple.Create(TokenType.RangeSeparator, "..");
+                        }
+                        break;
+                    case State.Error:
+                        return Tuple.Create(TokenType.Error, "");
+                }
+            }
+        }
+    }
+}
+
+}

--- a/Svg2Ico/IcoResolution.cs
+++ b/Svg2Ico/IcoResolution.cs
@@ -1,0 +1,39 @@
+﻿namespace Svg2Ico
+{
+
+struct IcoResolution
+{
+    public readonly int Width;
+
+    public byte IcoHeaderWidth
+    {
+        get
+        {
+            return (byte) Width;
+        }
+    }
+
+    public readonly int Height;
+
+    public byte IcoHeaderHeight
+    {
+        get
+        {
+            return (byte) Height;
+        }
+    }
+    
+    public IcoResolution(IcoSize size)
+    {
+        Width = size.Value;
+        Height = size.Value;
+    }
+    
+    public IcoResolution(IcoSize width, IcoSize height)
+    {
+        Width = width.Value;
+        Height = height.Value;
+    }
+}
+
+}

--- a/Svg2Ico/IcoSize.cs
+++ b/Svg2Ico/IcoSize.cs
@@ -1,0 +1,27 @@
+﻿namespace Svg2Ico
+{
+
+class IcoSize
+{
+    public readonly int Value;
+
+    public static bool TryGetInstance(int value, out IcoSize size)
+    {
+        if (value < 0 || value > 256)
+        {
+            size = null;
+            return false;
+        } else
+        {
+            size = new IcoSize(value);
+            return true;
+        }
+    }
+
+    private IcoSize(int value)
+    {
+        Value = value;
+    }
+}
+
+}

--- a/Svg2Ico/Mono.Options/Options.cs
+++ b/Svg2Ico/Mono.Options/Options.cs
@@ -1,0 +1,1366 @@
+//
+// Options.cs
+//
+// Authors:
+//  Jonathan Pryor <jpryor@novell.com>
+//  Federico Di Gregorio <fog@initd.org>
+//  Rolf Bjarne Kvinge <rolf@xamarin.com>
+//
+// Copyright (C) 2008 Novell (http://www.novell.com)
+// Copyright (C) 2009 Federico Di Gregorio.
+// Copyright (C) 2012 Xamarin Inc (http://www.xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+// Compile With:
+//   gmcs -debug+ -r:System.Core Options.cs -o:NDesk.Options.dll
+//   gmcs -debug+ -d:LINQ -r:System.Core Options.cs -o:NDesk.Options.dll
+//
+// The LINQ version just changes the implementation of
+// OptionSet.Parse(IEnumerable<string>), and confers no semantic changes.
+
+//
+// A Getopt::Long-inspired option parsing library for C#.
+//
+// NDesk.Options.OptionSet is built upon a key/value table, where the
+// key is a option format string and the value is a delegate that is 
+// invoked when the format string is matched.
+//
+// Option format strings:
+//  Regex-like BNF Grammar: 
+//    name: .+
+//    type: [=:]
+//    sep: ( [^{}]+ | '{' .+ '}' )?
+//    aliases: ( name type sep ) ( '|' name type sep )*
+// 
+// Each '|'-delimited name is an alias for the associated action.  If the
+// format string ends in a '=', it has a required value.  If the format
+// string ends in a ':', it has an optional value.  If neither '=' or ':'
+// is present, no value is supported.  `=' or `:' need only be defined on one
+// alias, but if they are provided on more than one they must be consistent.
+//
+// Each alias portion may also end with a "key/value separator", which is used
+// to split option values if the option accepts > 1 value.  If not specified,
+// it defaults to '=' and ':'.  If specified, it can be any character except
+// '{' and '}' OR the *string* between '{' and '}'.  If no separator should be
+// used (i.e. the separate values should be distinct arguments), then "{}"
+// should be used as the separator.
+//
+// Options are extracted either from the current option by looking for
+// the option name followed by an '=' or ':', or is taken from the
+// following option IFF:
+//  - The current option does not contain a '=' or a ':'
+//  - The current option requires a value (i.e. not a Option type of ':')
+//
+// The `name' used in the option format string does NOT include any leading
+// option indicator, such as '-', '--', or '/'.  All three of these are
+// permitted/required on any named option.
+//
+// Option bundling is permitted so long as:
+//   - '-' is used to start the option group
+//   - all of the bundled options are a single character
+//   - at most one of the bundled options accepts a value, and the value
+//     provided starts from the next character to the end of the string.
+//
+// This allows specifying '-a -b -c' as '-abc', and specifying '-D name=value'
+// as '-Dname=value'.
+//
+// Option processing is disabled by specifying "--".  All options after "--"
+// are returned by OptionSet.Parse() unchanged and unprocessed.
+//
+// Unprocessed options are returned from OptionSet.Parse().
+//
+// Examples:
+//  int verbose = 0;
+//  OptionSet p = new OptionSet ()
+//    .Add ("v", v => ++verbose)
+//    .Add ("name=|value=", v => Console.WriteLine (v));
+//  p.Parse (new string[]{"-v", "--v", "/v", "-name=A", "/name", "B", "extra"});
+//
+// The above would parse the argument string array, and would invoke the
+// lambda expression three times, setting `verbose' to 3 when complete.  
+// It would also print out "A" and "B" to standard output.
+// The returned array would contain the string "extra".
+//
+// C# 3.0 collection initializers are supported and encouraged:
+//  var p = new OptionSet () {
+//    { "h|?|help", v => ShowHelp () },
+//  };
+//
+// System.ComponentModel.TypeConverter is also supported, allowing the use of
+// custom data types in the callback type; TypeConverter.ConvertFromString()
+// is used to convert the value option to an instance of the specified
+// type:
+//
+//  var p = new OptionSet () {
+//    { "foo=", (Foo f) => Console.WriteLine (f.ToString ()) },
+//  };
+//
+// Random other tidbits:
+//  - Boolean options (those w/o '=' or ':' in the option format string)
+//    are explicitly enabled if they are followed with '+', and explicitly
+//    disabled if they are followed with '-':
+//      string a = null;
+//      var p = new OptionSet () {
+//        { "a", s => a = s },
+//      };
+//      p.Parse (new string[]{"-a"});   // sets v != null
+//      p.Parse (new string[]{"-a+"});  // sets v != null
+//      p.Parse (new string[]{"-a-"});  // sets v == null
+//
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Globalization;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Security.Permissions;
+using System.Text;
+using System.Text.RegularExpressions;
+
+#if LINQ
+using System.Linq;
+#endif
+
+#if TEST
+using NDesk.Options;
+#endif
+
+#if NDESK_OPTIONS
+namespace NDesk.Options
+#else
+namespace Mono.Options
+#endif
+{
+	static class StringCoda {
+
+		public static IEnumerable<string> WrappedLines (string self, params int[] widths)
+		{
+			IEnumerable<int> w = widths;
+			return WrappedLines (self, w);
+		}
+
+		public static IEnumerable<string> WrappedLines (string self, IEnumerable<int> widths)
+		{
+			if (widths == null)
+				throw new ArgumentNullException ("widths");
+			return CreateWrappedLinesIterator (self, widths);
+		}
+
+		private static IEnumerable<string> CreateWrappedLinesIterator (string self, IEnumerable<int> widths)
+		{
+			if (string.IsNullOrEmpty (self)) {
+				yield return string.Empty;
+				yield break;
+			}
+			using (IEnumerator<int> ewidths = widths.GetEnumerator ()) {
+				bool? hw = null;
+				int width = GetNextWidth (ewidths, int.MaxValue, ref hw);
+				int start = 0, end;
+				do {
+					end = GetLineEnd (start, width, self);
+					char c = self [end-1];
+					if (char.IsWhiteSpace (c))
+						--end;
+					bool needContinuation = end != self.Length && !IsEolChar (c);
+					string continuation = "";
+					if (needContinuation) {
+						--end;
+						continuation = "-";
+					}
+					string line = self.Substring (start, end - start) + continuation;
+					yield return line;
+					start = end;
+					if (char.IsWhiteSpace (c))
+						++start;
+					width = GetNextWidth (ewidths, width, ref hw);
+				} while (start < self.Length);
+			}
+		}
+
+		private static int GetNextWidth (IEnumerator<int> ewidths, int curWidth, ref bool? eValid)
+		{
+			if (!eValid.HasValue || (eValid.HasValue && eValid.Value)) {
+				curWidth = (eValid = ewidths.MoveNext ()).Value ? ewidths.Current : curWidth;
+				// '.' is any character, - is for a continuation
+				const string minWidth = ".-";
+				if (curWidth < minWidth.Length)
+					throw new ArgumentOutOfRangeException ("widths",
+							string.Format ("Element must be >= {0}, was {1}.", minWidth.Length, curWidth));
+				return curWidth;
+			}
+			// no more elements, use the last element.
+			return curWidth;
+		}
+
+		private static bool IsEolChar (char c)
+		{
+			return !char.IsLetterOrDigit (c);
+		}
+
+		private static int GetLineEnd (int start, int length, string description)
+		{
+			int end = System.Math.Min (start + length, description.Length);
+			int sep = -1;
+			for (int i = start; i < end; ++i) {
+				if (description [i] == '\n')
+					return i+1;
+				if (IsEolChar (description [i]))
+					sep = i+1;
+			}
+			if (sep == -1 || end == description.Length)
+				return end;
+			return sep;
+		}
+	}
+
+	public class OptionValueCollection : IList, IList<string> {
+
+		List<string> values = new List<string> ();
+		OptionContext c;
+
+		internal OptionValueCollection (OptionContext c)
+		{
+			this.c = c;
+		}
+
+		#region ICollection
+		void ICollection.CopyTo (Array array, int index)  {(values as ICollection).CopyTo (array, index);}
+		bool ICollection.IsSynchronized                   {get {return (values as ICollection).IsSynchronized;}}
+		object ICollection.SyncRoot                       {get {return (values as ICollection).SyncRoot;}}
+		#endregion
+
+		#region ICollection<T>
+		public void Add (string item)                       {values.Add (item);}
+		public void Clear ()                                {values.Clear ();}
+		public bool Contains (string item)                  {return values.Contains (item);}
+		public void CopyTo (string[] array, int arrayIndex) {values.CopyTo (array, arrayIndex);}
+		public bool Remove (string item)                    {return values.Remove (item);}
+		public int Count                                    {get {return values.Count;}}
+		public bool IsReadOnly                              {get {return false;}}
+		#endregion
+
+		#region IEnumerable
+		IEnumerator IEnumerable.GetEnumerator () {return values.GetEnumerator ();}
+		#endregion
+
+		#region IEnumerable<T>
+		public IEnumerator<string> GetEnumerator () {return values.GetEnumerator ();}
+		#endregion
+
+		#region IList
+		int IList.Add (object value)                {return (values as IList).Add (value);}
+		bool IList.Contains (object value)          {return (values as IList).Contains (value);}
+		int IList.IndexOf (object value)            {return (values as IList).IndexOf (value);}
+		void IList.Insert (int index, object value) {(values as IList).Insert (index, value);}
+		void IList.Remove (object value)            {(values as IList).Remove (value);}
+		void IList.RemoveAt (int index)             {(values as IList).RemoveAt (index);}
+		bool IList.IsFixedSize                      {get {return false;}}
+		object IList.this [int index]               {get {return this [index];} set {(values as IList)[index] = value;}}
+		#endregion
+
+		#region IList<T>
+		public int IndexOf (string item)            {return values.IndexOf (item);}
+		public void Insert (int index, string item) {values.Insert (index, item);}
+		public void RemoveAt (int index)            {values.RemoveAt (index);}
+
+		private void AssertValid (int index)
+		{
+			if (c.Option == null)
+				throw new InvalidOperationException ("OptionContext.Option is null.");
+			if (index >= c.Option.MaxValueCount)
+				throw new ArgumentOutOfRangeException ("index");
+			if (c.Option.OptionValueType == OptionValueType.Required &&
+					index >= values.Count)
+				throw new OptionException (string.Format (
+							c.OptionSet.MessageLocalizer ("Missing required value for option '{0}'."), c.OptionName), 
+						c.OptionName);
+		}
+
+		public string this [int index] {
+			get {
+				AssertValid (index);
+				return index >= values.Count ? null : values [index];
+			}
+			set {
+				values [index] = value;
+			}
+		}
+		#endregion
+
+		public List<string> ToList ()
+		{
+			return new List<string> (values);
+		}
+
+		public string[] ToArray ()
+		{
+			return values.ToArray ();
+		}
+
+		public override string ToString ()
+		{
+			return string.Join (", ", values.ToArray ());
+		}
+	}
+
+	public class OptionContext {
+		private Option                option;
+		private string                name;
+		private int                   index;
+		private OptionSet             set;
+		private OptionValueCollection c;
+
+		public OptionContext (OptionSet set)
+		{
+			this.set = set;
+			this.c   = new OptionValueCollection (this);
+		}
+
+		public Option Option {
+			get {return option;}
+			set {option = value;}
+		}
+
+		public string OptionName { 
+			get {return name;}
+			set {name = value;}
+		}
+
+		public int OptionIndex {
+			get {return index;}
+			set {index = value;}
+		}
+
+		public OptionSet OptionSet {
+			get {return set;}
+		}
+
+		public OptionValueCollection OptionValues {
+			get {return c;}
+		}
+	}
+
+	public enum OptionValueType {
+		None, 
+		Optional,
+		Required,
+	}
+
+	public abstract class Option {
+		string prototype, description;
+		string[] names;
+		OptionValueType type;
+		int count;
+		string[] separators;
+		bool hidden;
+
+		protected Option (string prototype, string description)
+			: this (prototype, description, 1, false)
+		{
+		}
+
+		protected Option (string prototype, string description, int maxValueCount)
+			: this (prototype, description, maxValueCount, false)
+		{
+		}
+
+		protected Option (string prototype, string description, int maxValueCount, bool hidden)
+		{
+			if (prototype == null)
+				throw new ArgumentNullException ("prototype");
+			if (prototype.Length == 0)
+				throw new ArgumentException ("Cannot be the empty string.", "prototype");
+			if (maxValueCount < 0)
+				throw new ArgumentOutOfRangeException ("maxValueCount");
+
+			this.prototype   = prototype;
+			this.description = description;
+			this.count       = maxValueCount;
+			this.names       = (this is OptionSet.Category)
+				// append GetHashCode() so that "duplicate" categories have distinct
+				// names, e.g. adding multiple "" categories should be valid.
+				? new[]{prototype + this.GetHashCode ()}
+				: prototype.Split ('|');
+
+			if (this is OptionSet.Category)
+				return;
+
+			this.type        = ParsePrototype ();
+			this.hidden      = hidden;
+
+			if (this.count == 0 && type != OptionValueType.None)
+				throw new ArgumentException (
+						"Cannot provide maxValueCount of 0 for OptionValueType.Required or " +
+							"OptionValueType.Optional.",
+						"maxValueCount");
+			if (this.type == OptionValueType.None && maxValueCount > 1)
+				throw new ArgumentException (
+						string.Format ("Cannot provide maxValueCount of {0} for OptionValueType.None.", maxValueCount),
+						"maxValueCount");
+			if (Array.IndexOf (names, "<>") >= 0 && 
+					((names.Length == 1 && this.type != OptionValueType.None) ||
+					 (names.Length > 1 && this.MaxValueCount > 1)))
+				throw new ArgumentException (
+						"The default option handler '<>' cannot require values.",
+						"prototype");
+		}
+
+		public string           Prototype       {get {return prototype;}}
+		public string           Description     {get {return description;}}
+		public OptionValueType  OptionValueType {get {return type;}}
+		public int              MaxValueCount   {get {return count;}}
+		public bool             Hidden          {get {return hidden;}}
+
+		public string[] GetNames ()
+		{
+			return (string[]) names.Clone ();
+		}
+
+		public string[] GetValueSeparators ()
+		{
+			if (separators == null)
+				return new string [0];
+			return (string[]) separators.Clone ();
+		}
+
+		protected static T Parse<T> (string value, OptionContext c)
+		{
+			Type tt = typeof (T);
+			bool nullable = tt.IsValueType && tt.IsGenericType && 
+				!tt.IsGenericTypeDefinition && 
+				tt.GetGenericTypeDefinition () == typeof (Nullable<>);
+			Type targetType = nullable ? tt.GetGenericArguments () [0] : typeof (T);
+			TypeConverter conv = TypeDescriptor.GetConverter (targetType);
+			T t = default (T);
+			try {
+				if (value != null)
+					t = (T) conv.ConvertFromString (value);
+			}
+			catch (Exception e) {
+				throw new OptionException (
+						string.Format (
+							c.OptionSet.MessageLocalizer ("Could not convert string `{0}' to type {1} for option `{2}'."),
+							value, targetType.Name, c.OptionName),
+						c.OptionName, e);
+			}
+			return t;
+		}
+
+		internal string[] Names           {get {return names;}}
+		internal string[] ValueSeparators {get {return separators;}}
+
+		static readonly char[] NameTerminator = new char[]{'=', ':'};
+
+		private OptionValueType ParsePrototype ()
+		{
+			char type = '\0';
+			List<string> seps = new List<string> ();
+			for (int i = 0; i < names.Length; ++i) {
+				string name = names [i];
+				if (name.Length == 0)
+					throw new ArgumentException ("Empty option names are not supported.", "prototype");
+
+				int end = name.IndexOfAny (NameTerminator);
+				if (end == -1)
+					continue;
+				names [i] = name.Substring (0, end);
+				if (type == '\0' || type == name [end])
+					type = name [end];
+				else 
+					throw new ArgumentException (
+							string.Format ("Conflicting option types: '{0}' vs. '{1}'.", type, name [end]),
+							"prototype");
+				AddSeparators (name, end, seps);
+			}
+
+			if (type == '\0')
+				return OptionValueType.None;
+
+			if (count <= 1 && seps.Count != 0)
+				throw new ArgumentException (
+						string.Format ("Cannot provide key/value separators for Options taking {0} value(s).", count),
+						"prototype");
+			if (count > 1) {
+				if (seps.Count == 0)
+					this.separators = new string[]{":", "="};
+				else if (seps.Count == 1 && seps [0].Length == 0)
+					this.separators = null;
+				else
+					this.separators = seps.ToArray ();
+			}
+
+			return type == '=' ? OptionValueType.Required : OptionValueType.Optional;
+		}
+
+		private static void AddSeparators (string name, int end, ICollection<string> seps)
+		{
+			int start = -1;
+			for (int i = end+1; i < name.Length; ++i) {
+				switch (name [i]) {
+					case '{':
+						if (start != -1)
+							throw new ArgumentException (
+									string.Format ("Ill-formed name/value separator found in \"{0}\".", name),
+									"prototype");
+						start = i+1;
+						break;
+					case '}':
+						if (start == -1)
+							throw new ArgumentException (
+									string.Format ("Ill-formed name/value separator found in \"{0}\".", name),
+									"prototype");
+						seps.Add (name.Substring (start, i-start));
+						start = -1;
+						break;
+					default:
+						if (start == -1)
+							seps.Add (name [i].ToString ());
+						break;
+				}
+			}
+			if (start != -1)
+				throw new ArgumentException (
+						string.Format ("Ill-formed name/value separator found in \"{0}\".", name),
+						"prototype");
+		}
+
+		public void Invoke (OptionContext c)
+		{
+			OnParseComplete (c);
+			c.OptionName  = null;
+			c.Option      = null;
+			c.OptionValues.Clear ();
+		}
+
+		protected abstract void OnParseComplete (OptionContext c);
+
+		public override string ToString ()
+		{
+			return Prototype;
+		}
+	}
+
+	public abstract class ArgumentSource {
+
+		protected ArgumentSource ()
+		{
+		}
+
+		public abstract string[] GetNames ();
+		public abstract string Description { get; }
+		public abstract bool GetArguments (string value, out IEnumerable<string> replacement);
+
+		public static IEnumerable<string> GetArgumentsFromFile (string file)
+		{
+			return GetArguments (File.OpenText (file), true);
+		}
+
+		public static IEnumerable<string> GetArguments (TextReader reader)
+		{
+			return GetArguments (reader, false);
+		}
+
+		// Cribbed from mcs/driver.cs:LoadArgs(string)
+		static IEnumerable<string> GetArguments (TextReader reader, bool close)
+		{
+			try {
+				StringBuilder arg = new StringBuilder ();
+
+				string line;
+				while ((line = reader.ReadLine ()) != null) {
+					int t = line.Length;
+
+					for (int i = 0; i < t; i++) {
+						char c = line [i];
+						
+						if (c == '"' || c == '\'') {
+							char end = c;
+							
+							for (i++; i < t; i++){
+								c = line [i];
+
+								if (c == end)
+									break;
+								arg.Append (c);
+							}
+						} else if (c == ' ') {
+							if (arg.Length > 0) {
+								yield return arg.ToString ();
+								arg.Length = 0;
+							}
+						} else
+							arg.Append (c);
+					}
+					if (arg.Length > 0) {
+						yield return arg.ToString ();
+						arg.Length = 0;
+					}
+				}
+			}
+			finally {
+				if (close)
+					reader.Close ();
+			}
+		}
+	}
+
+	public class ResponseFileSource : ArgumentSource {
+
+		public override string[] GetNames ()
+		{
+			return new string[]{"@file"};
+		}
+
+		public override string Description {
+			get {return "Read response file for more options.";}
+		}
+
+		public override bool GetArguments (string value, out IEnumerable<string> replacement)
+		{
+			if (string.IsNullOrEmpty (value) || !value.StartsWith ("@")) {
+				replacement = null;
+				return false;
+			}
+			replacement = ArgumentSource.GetArgumentsFromFile (value.Substring (1));
+			return true;
+		}
+	}
+
+	[Serializable]
+	public class OptionException : Exception {
+		private string option;
+
+		public OptionException ()
+		{
+		}
+
+		public OptionException (string message, string optionName)
+			: base (message)
+		{
+			this.option = optionName;
+		}
+
+		public OptionException (string message, string optionName, Exception innerException)
+			: base (message, innerException)
+		{
+			this.option = optionName;
+		}
+
+		protected OptionException (SerializationInfo info, StreamingContext context)
+			: base (info, context)
+		{
+			this.option = info.GetString ("OptionName");
+		}
+
+		public string OptionName {
+			get {return this.option;}
+		}
+
+		[SecurityPermission (SecurityAction.LinkDemand, SerializationFormatter = true)]
+		public override void GetObjectData (SerializationInfo info, StreamingContext context)
+		{
+			base.GetObjectData (info, context);
+			info.AddValue ("OptionName", option);
+		}
+	}
+
+	public delegate void OptionAction<TKey, TValue> (TKey key, TValue value);
+
+	public class OptionSet : KeyedCollection<string, Option>
+	{
+		public OptionSet ()
+			: this (delegate (string f) {return f;})
+		{
+		}
+
+		public OptionSet (Converter<string, string> localizer)
+		{
+			this.localizer = localizer;
+			this.roSources = new ReadOnlyCollection<ArgumentSource>(sources);
+		}
+
+		Converter<string, string> localizer;
+
+		public Converter<string, string> MessageLocalizer {
+			get {return localizer;}
+		}
+
+		List<ArgumentSource> sources = new List<ArgumentSource> ();
+		ReadOnlyCollection<ArgumentSource> roSources;
+
+		public ReadOnlyCollection<ArgumentSource> ArgumentSources {
+			get {return roSources;}
+		}
+
+
+		protected override string GetKeyForItem (Option item)
+		{
+			if (item == null)
+				throw new ArgumentNullException ("option");
+			if (item.Names != null && item.Names.Length > 0)
+				return item.Names [0];
+			// This should never happen, as it's invalid for Option to be
+			// constructed w/o any names.
+			throw new InvalidOperationException ("Option has no names!");
+		}
+
+		[Obsolete ("Use KeyedCollection.this[string]")]
+		protected Option GetOptionForName (string option)
+		{
+			if (option == null)
+				throw new ArgumentNullException ("option");
+			try {
+				return base [option];
+			}
+			catch (KeyNotFoundException) {
+				return null;
+			}
+		}
+
+		protected override void InsertItem (int index, Option item)
+		{
+			base.InsertItem (index, item);
+			AddImpl (item);
+		}
+
+		protected override void RemoveItem (int index)
+		{
+			Option p = Items [index];
+			base.RemoveItem (index);
+			// KeyedCollection.RemoveItem() handles the 0th item
+			for (int i = 1; i < p.Names.Length; ++i) {
+				Dictionary.Remove (p.Names [i]);
+			}
+		}
+
+		protected override void SetItem (int index, Option item)
+		{
+			base.SetItem (index, item);
+			AddImpl (item);
+		}
+
+		private void AddImpl (Option option)
+		{
+			if (option == null)
+				throw new ArgumentNullException ("option");
+			List<string> added = new List<string> (option.Names.Length);
+			try {
+				// KeyedCollection.InsertItem/SetItem handle the 0th name.
+				for (int i = 1; i < option.Names.Length; ++i) {
+					Dictionary.Add (option.Names [i], option);
+					added.Add (option.Names [i]);
+				}
+			}
+			catch (Exception) {
+				foreach (string name in added)
+					Dictionary.Remove (name);
+				throw;
+			}
+		}
+
+		public OptionSet Add (string header)
+		{
+			if (header == null)
+				throw new ArgumentNullException ("header");
+			Add (new Category (header));
+			return this;
+		}
+
+		internal sealed class Category : Option {
+
+			// Prototype starts with '=' because this is an invalid prototype
+			// (see Option.ParsePrototype(), and thus it'll prevent Category
+			// instances from being accidentally used as normal options.
+			public Category (string description)
+				: base ("=:Category:= " + description, description)
+			{
+			}
+
+			protected override void OnParseComplete (OptionContext c)
+			{
+				throw new NotSupportedException ("Category.OnParseComplete should not be invoked.");
+			}
+		}
+
+
+		public new OptionSet Add (Option option)
+		{
+			base.Add (option);
+			return this;
+		}
+
+		sealed class ActionOption : Option {
+			Action<OptionValueCollection> action;
+
+			public ActionOption (string prototype, string description, int count, Action<OptionValueCollection> action)
+				: this (prototype, description, count, action, false)
+			{
+			}
+
+			public ActionOption (string prototype, string description, int count, Action<OptionValueCollection> action, bool hidden)
+				: base (prototype, description, count, hidden)
+			{
+				if (action == null)
+					throw new ArgumentNullException ("action");
+				this.action = action;
+			}
+
+			protected override void OnParseComplete (OptionContext c)
+			{
+				action (c.OptionValues);
+			}
+		}
+
+		public OptionSet Add (string prototype, Action<string> action)
+		{
+			return Add (prototype, null, action);
+		}
+
+		public OptionSet Add (string prototype, string description, Action<string> action)
+		{
+			return Add (prototype, description, action, false);
+		}
+
+		public OptionSet Add (string prototype, string description, Action<string> action, bool hidden)
+		{
+			if (action == null)
+				throw new ArgumentNullException ("action");
+			Option p = new ActionOption (prototype, description, 1, 
+					delegate (OptionValueCollection v) { action (v [0]); }, hidden);
+			base.Add (p);
+			return this;
+		}
+
+		public OptionSet Add (string prototype, OptionAction<string, string> action)
+		{
+			return Add (prototype, null, action);
+		}
+
+		public OptionSet Add (string prototype, string description, OptionAction<string, string> action)
+		{
+			return Add (prototype, description, action, false);
+		}
+
+		public OptionSet Add (string prototype, string description, OptionAction<string, string> action, bool hidden)	{
+			if (action == null)
+				throw new ArgumentNullException ("action");
+			Option p = new ActionOption (prototype, description, 2, 
+					delegate (OptionValueCollection v) {action (v [0], v [1]);}, hidden);
+			base.Add (p);
+			return this;
+		}
+
+		sealed class ActionOption<T> : Option {
+			Action<T> action;
+
+			public ActionOption (string prototype, string description, Action<T> action)
+				: base (prototype, description, 1)
+			{
+				if (action == null)
+					throw new ArgumentNullException ("action");
+				this.action = action;
+			}
+
+			protected override void OnParseComplete (OptionContext c)
+			{
+				action (Parse<T> (c.OptionValues [0], c));
+			}
+		}
+
+		sealed class ActionOption<TKey, TValue> : Option {
+			OptionAction<TKey, TValue> action;
+
+			public ActionOption (string prototype, string description, OptionAction<TKey, TValue> action)
+				: base (prototype, description, 2)
+			{
+				if (action == null)
+					throw new ArgumentNullException ("action");
+				this.action = action;
+			}
+
+			protected override void OnParseComplete (OptionContext c)
+			{
+				action (
+						Parse<TKey> (c.OptionValues [0], c),
+						Parse<TValue> (c.OptionValues [1], c));
+			}
+		}
+
+		public OptionSet Add<T> (string prototype, Action<T> action)
+		{
+			return Add (prototype, null, action);
+		}
+
+		public OptionSet Add<T> (string prototype, string description, Action<T> action)
+		{
+			return Add (new ActionOption<T> (prototype, description, action));
+		}
+
+		public OptionSet Add<TKey, TValue> (string prototype, OptionAction<TKey, TValue> action)
+		{
+			return Add (prototype, null, action);
+		}
+
+		public OptionSet Add<TKey, TValue> (string prototype, string description, OptionAction<TKey, TValue> action)
+		{
+			return Add (new ActionOption<TKey, TValue> (prototype, description, action));
+		}
+
+		public OptionSet Add (ArgumentSource source)
+		{
+			if (source == null)
+				throw new ArgumentNullException ("source");
+			sources.Add (source);
+			return this;
+		}
+
+		protected virtual OptionContext CreateOptionContext ()
+		{
+			return new OptionContext (this);
+		}
+
+		public List<string> Parse (IEnumerable<string> arguments)
+		{
+			if (arguments == null)
+				throw new ArgumentNullException ("arguments");
+			OptionContext c = CreateOptionContext ();
+			c.OptionIndex = -1;
+			bool process = true;
+			List<string> unprocessed = new List<string> ();
+			Option def = Contains ("<>") ? this ["<>"] : null;
+			ArgumentEnumerator ae = new ArgumentEnumerator (arguments);
+			foreach (string argument in ae) {
+				++c.OptionIndex;
+				if (argument == "--") {
+					process = false;
+					continue;
+				}
+				if (!process) {
+					Unprocessed (unprocessed, def, c, argument);
+					continue;
+				}
+				if (AddSource (ae, argument))
+					continue;
+				if (!Parse (argument, c))
+					Unprocessed (unprocessed, def, c, argument);
+			}
+			if (c.Option != null)
+				c.Option.Invoke (c);
+			return unprocessed;
+		}
+
+		class ArgumentEnumerator : IEnumerable<string> {
+			List<IEnumerator<string>> sources = new List<IEnumerator<string>> ();
+
+			public ArgumentEnumerator (IEnumerable<string> arguments)
+			{
+				sources.Add (arguments.GetEnumerator ());
+			}
+
+			public void Add (IEnumerable<string> arguments)
+			{
+				sources.Add (arguments.GetEnumerator ());
+			}
+
+			public IEnumerator<string> GetEnumerator ()
+			{
+				do {
+					IEnumerator<string> c = sources [sources.Count-1];
+					if (c.MoveNext ())
+						yield return c.Current;
+					else {
+						c.Dispose ();
+						sources.RemoveAt (sources.Count-1);
+					}
+				} while (sources.Count > 0);
+			}
+
+			IEnumerator IEnumerable.GetEnumerator ()
+			{
+				return GetEnumerator ();
+			}
+		}
+
+		bool AddSource (ArgumentEnumerator ae, string argument)
+		{
+			foreach (ArgumentSource source in sources) {
+				IEnumerable<string> replacement;
+				if (!source.GetArguments (argument, out replacement))
+					continue;
+				ae.Add (replacement);
+				return true;
+			}
+			return false;
+		}
+
+		private static bool Unprocessed (ICollection<string> extra, Option def, OptionContext c, string argument)
+		{
+			if (def == null) {
+				extra.Add (argument);
+				return false;
+			}
+			c.OptionValues.Add (argument);
+			c.Option = def;
+			c.Option.Invoke (c);
+			return false;
+		}
+
+		private readonly Regex ValueOption = new Regex (
+			@"^(?<flag>--|-|/)(?<name>[^:=]+)((?<sep>[:=])(?<value>.*))?$");
+
+		protected bool GetOptionParts (string argument, out string flag, out string name, out string sep, out string value)
+		{
+			if (argument == null)
+				throw new ArgumentNullException ("argument");
+
+			flag = name = sep = value = null;
+			Match m = ValueOption.Match (argument);
+			if (!m.Success) {
+				return false;
+			}
+			flag  = m.Groups ["flag"].Value;
+			name  = m.Groups ["name"].Value;
+			if (m.Groups ["sep"].Success && m.Groups ["value"].Success) {
+				sep   = m.Groups ["sep"].Value;
+				value = m.Groups ["value"].Value;
+			}
+			return true;
+		}
+
+		protected virtual bool Parse (string argument, OptionContext c)
+		{
+			if (c.Option != null) {
+				ParseValue (argument, c);
+				return true;
+			}
+
+			string f, n, s, v;
+			if (!GetOptionParts (argument, out f, out n, out s, out v))
+				return false;
+
+			Option p;
+			if (Contains (n)) {
+				p = this [n];
+				c.OptionName = f + n;
+				c.Option     = p;
+				switch (p.OptionValueType) {
+					case OptionValueType.None:
+						c.OptionValues.Add (n);
+						c.Option.Invoke (c);
+						break;
+					case OptionValueType.Optional:
+					case OptionValueType.Required: 
+						ParseValue (v, c);
+						break;
+				}
+				return true;
+			}
+			// no match; is it a bool option?
+			if (ParseBool (argument, n, c))
+				return true;
+			// is it a bundled option?
+			if (ParseBundledValue (f, string.Concat (n + s + v), c))
+				return true;
+
+			return false;
+		}
+
+		private void ParseValue (string option, OptionContext c)
+		{
+			if (option != null)
+				foreach (string o in c.Option.ValueSeparators != null 
+						? option.Split (c.Option.ValueSeparators, c.Option.MaxValueCount - c.OptionValues.Count, StringSplitOptions.None)
+						: new string[]{option}) {
+					c.OptionValues.Add (o);
+				}
+			if (c.OptionValues.Count == c.Option.MaxValueCount || 
+					c.Option.OptionValueType == OptionValueType.Optional)
+				c.Option.Invoke (c);
+			else if (c.OptionValues.Count > c.Option.MaxValueCount) {
+				throw new OptionException (localizer (string.Format (
+								"Error: Found {0} option values when expecting {1}.", 
+								c.OptionValues.Count, c.Option.MaxValueCount)),
+						c.OptionName);
+			}
+		}
+
+		private bool ParseBool (string option, string n, OptionContext c)
+		{
+			Option p;
+			string rn;
+			if (n.Length >= 1 && (n [n.Length-1] == '+' || n [n.Length-1] == '-') &&
+					Contains ((rn = n.Substring (0, n.Length-1)))) {
+				p = this [rn];
+				string v = n [n.Length-1] == '+' ? option : null;
+				c.OptionName  = option;
+				c.Option      = p;
+				c.OptionValues.Add (v);
+				p.Invoke (c);
+				return true;
+			}
+			return false;
+		}
+
+		private bool ParseBundledValue (string f, string n, OptionContext c)
+		{
+			if (f != "-")
+				return false;
+			for (int i = 0; i < n.Length; ++i) {
+				Option p;
+				string opt = f + n [i].ToString ();
+				string rn = n [i].ToString ();
+				if (!Contains (rn)) {
+					if (i == 0)
+						return false;
+					throw new OptionException (string.Format (localizer (
+									"Cannot bundle unregistered option '{0}'."), opt), opt);
+				}
+				p = this [rn];
+				switch (p.OptionValueType) {
+					case OptionValueType.None:
+						Invoke (c, opt, n, p);
+						break;
+					case OptionValueType.Optional:
+					case OptionValueType.Required: {
+						string v     = n.Substring (i+1);
+						c.Option     = p;
+						c.OptionName = opt;
+						ParseValue (v.Length != 0 ? v : null, c);
+						return true;
+					}
+					default:
+						throw new InvalidOperationException ("Unknown OptionValueType: " + p.OptionValueType);
+				}
+			}
+			return true;
+		}
+
+		private static void Invoke (OptionContext c, string name, string value, Option option)
+		{
+			c.OptionName  = name;
+			c.Option      = option;
+			c.OptionValues.Add (value);
+			option.Invoke (c);
+		}
+
+		private const int OptionWidth = 29;
+		private const int Description_FirstWidth  = 80 - OptionWidth;
+		private const int Description_RemWidth    = 80 - OptionWidth - 2;
+
+		public void WriteOptionDescriptions (TextWriter o)
+		{
+			foreach (Option p in this) {
+				int written = 0;
+
+				if (p.Hidden)
+					continue;
+
+				Category c = p as Category;
+				if (c != null) {
+					WriteDescription (o, p.Description, "", 80, 80);
+					continue;
+				}
+
+				if (!WriteOptionPrototype (o, p, ref written))
+					continue;
+
+				if (written < OptionWidth)
+					o.Write (new string (' ', OptionWidth - written));
+				else {
+					o.WriteLine ();
+					o.Write (new string (' ', OptionWidth));
+				}
+
+				WriteDescription (o, p.Description, new string (' ', OptionWidth+2),
+						Description_FirstWidth, Description_RemWidth);
+			}
+
+			foreach (ArgumentSource s in sources) {
+				string[] names = s.GetNames ();
+				if (names == null || names.Length == 0)
+					continue;
+
+				int written = 0;
+
+				Write (o, ref written, "  ");
+				Write (o, ref written, names [0]);
+				for (int i = 1; i < names.Length; ++i) {
+					Write (o, ref written, ", ");
+					Write (o, ref written, names [i]);
+				}
+
+				if (written < OptionWidth)
+					o.Write (new string (' ', OptionWidth - written));
+				else {
+					o.WriteLine ();
+					o.Write (new string (' ', OptionWidth));
+				}
+
+				WriteDescription (o, s.Description, new string (' ', OptionWidth+2),
+						Description_FirstWidth, Description_RemWidth);
+			}
+		}
+
+		void WriteDescription (TextWriter o, string value, string prefix, int firstWidth, int remWidth)
+		{
+			bool indent = false;
+			foreach (string line in GetLines (localizer (GetDescription (value)), firstWidth, remWidth)) {
+				if (indent)
+					o.Write (prefix);
+				o.WriteLine (line);
+				indent = true;
+			}
+		}
+
+		bool WriteOptionPrototype (TextWriter o, Option p, ref int written)
+		{
+			string[] names = p.Names;
+
+			int i = GetNextOptionIndex (names, 0);
+			if (i == names.Length)
+				return false;
+
+			if (names [i].Length == 1) {
+				Write (o, ref written, "  -");
+				Write (o, ref written, names [0]);
+			}
+			else {
+				Write (o, ref written, "      --");
+				Write (o, ref written, names [0]);
+			}
+
+			for ( i = GetNextOptionIndex (names, i+1); 
+					i < names.Length; i = GetNextOptionIndex (names, i+1)) {
+				Write (o, ref written, ", ");
+				Write (o, ref written, names [i].Length == 1 ? "-" : "--");
+				Write (o, ref written, names [i]);
+			}
+
+			if (p.OptionValueType == OptionValueType.Optional ||
+					p.OptionValueType == OptionValueType.Required) {
+				if (p.OptionValueType == OptionValueType.Optional) {
+					Write (o, ref written, localizer ("["));
+				}
+				Write (o, ref written, localizer ("=" + GetArgumentName (0, p.MaxValueCount, p.Description)));
+				string sep = p.ValueSeparators != null && p.ValueSeparators.Length > 0 
+					? p.ValueSeparators [0]
+					: " ";
+				for (int c = 1; c < p.MaxValueCount; ++c) {
+					Write (o, ref written, localizer (sep + GetArgumentName (c, p.MaxValueCount, p.Description)));
+				}
+				if (p.OptionValueType == OptionValueType.Optional) {
+					Write (o, ref written, localizer ("]"));
+				}
+			}
+			return true;
+		}
+
+		static int GetNextOptionIndex (string[] names, int i)
+		{
+			while (i < names.Length && names [i] == "<>") {
+				++i;
+			}
+			return i;
+		}
+
+		static void Write (TextWriter o, ref int n, string s)
+		{
+			n += s.Length;
+			o.Write (s);
+		}
+
+		private static string GetArgumentName (int index, int maxIndex, string description)
+		{
+			if (description == null)
+				return maxIndex == 1 ? "VALUE" : "VALUE" + (index + 1);
+			string[] nameStart;
+			if (maxIndex == 1)
+				nameStart = new string[]{"{0:", "{"};
+			else
+				nameStart = new string[]{"{" + index + ":"};
+			for (int i = 0; i < nameStart.Length; ++i) {
+				int start, j = 0;
+				do {
+					start = description.IndexOf (nameStart [i], j);
+				} while (start >= 0 && j != 0 ? description [j++ - 1] == '{' : false);
+				if (start == -1)
+					continue;
+				int end = description.IndexOf ("}", start);
+				if (end == -1)
+					continue;
+				return description.Substring (start + nameStart [i].Length, end - start - nameStart [i].Length);
+			}
+			return maxIndex == 1 ? "VALUE" : "VALUE" + (index + 1);
+		}
+
+		private static string GetDescription (string description)
+		{
+			if (description == null)
+				return string.Empty;
+			StringBuilder sb = new StringBuilder (description.Length);
+			int start = -1;
+			for (int i = 0; i < description.Length; ++i) {
+				switch (description [i]) {
+					case '{':
+						if (i == start) {
+							sb.Append ('{');
+							start = -1;
+						}
+						else if (start < 0)
+							start = i + 1;
+						break;
+					case '}':
+						if (start < 0) {
+							if ((i+1) == description.Length || description [i+1] != '}')
+								throw new InvalidOperationException ("Invalid option description: " + description);
+							++i;
+							sb.Append ("}");
+						}
+						else {
+							sb.Append (description.Substring (start, i - start));
+							start = -1;
+						}
+						break;
+					case ':':
+						if (start < 0)
+							goto default;
+						start = i + 1;
+						break;
+					default:
+						if (start < 0)
+							sb.Append (description [i]);
+						break;
+				}
+			}
+			return sb.ToString ();
+		}
+
+		private static IEnumerable<string> GetLines (string description, int firstWidth, int remWidth)
+		{
+			return StringCoda.WrappedLines (description, firstWidth, remWidth);
+		}
+	}
+}
+

--- a/Svg2Ico/Program.cs
+++ b/Svg2Ico/Program.cs
@@ -1,4 +1,4 @@
-﻿//svg2ico [--help] [--outdir <directory>] [--recurse] [--size <sizespec>] --[<path>...]
+﻿//svg2ico [--help] [--outdir <directory>] [--recurse] [--size <sizespec>] -- [<path>...]
 //
 // # Options
 //
@@ -290,7 +290,7 @@ class Program
     private static void ShowHelp()
     {
         Console.WriteLine(
-@"svg2ico[--help][--outdir<directory>][--recurse][--size<sizespec>]--[< path>...]
+@"svg2ico [--help] [--outdir<directory>] [--recurse] [--size<sizespec>] -- [<path>...]
 
 # Options
 
@@ -301,7 +301,7 @@ class Program
 
 <directory>
 
-    The directory in which to write.ico files.Writes them next to the
+    The directory in which to write .ico files. Writes them next to the
     .svg image that generated them if not specified.
 
 <path>
@@ -310,7 +310,7 @@ class Program
 
 <sizespec>
 
-    Resolution(s) to write in each.ico file.See below for the
+    Resolution(s) to write in each .ico file. See below for the
     format specification.
 
 -h, --help
@@ -327,7 +327,7 @@ class Program
 
 -s, --size
 
-    Specifies a resolution to place in each output.ico file. Use this
+    Specifies a resolution to place in each output .ico file. Use this
     option multiple times to specify multiple resolutions.
 
 # Size Specification

--- a/Svg2Ico/Program.cs
+++ b/Svg2Ico/Program.cs
@@ -1,0 +1,365 @@
+﻿//svg2ico [--help] [--outdir <directory>] [--recurse] [--size <sizespec>] --[<path>...]
+//
+// # Options
+//
+// <files>
+//
+//     A list of files and directories in which to search for .svg files
+//     to convert.
+//
+// <directory>
+//
+//     The directory in which to write .ico files. Writes them next to the
+//     .svg image that generated them if not specified.
+//
+// <path>
+//
+//     An SVG file, or a directory in which to look for .svg files.
+//		
+// <sizespec>
+//
+//     Resolution(s) to write in each .ico file. See below for the
+//     format specification.
+//
+// -h, --help
+//
+//     Prints some help text
+//
+// -o, --outdir
+//
+//     Specifies the output directory
+//
+// -r, --recurse
+//
+//     Recurse into any input directories when looking for .svg files.
+//
+// -s, --size
+//
+//     Specifies a resolution to place in each output .ico file. Use this
+//     option multiple times to specify multiple resolutions.
+//
+// # Size Specification
+//
+// Square: <s>
+//
+//     Where `s` is a number in the range [0, 256].
+//
+// Rectangle: <w>x<h>
+//
+//     Where `w` and `h` are numbers in the range [0, 256].
+//
+// Square powers of two: <n>..<m>
+//
+//     Where `n` and `m` are numbers in the range [0, 8] and m>= n. Represents
+//     images at resolutions of 2^n x 2^n, 2^(n+1) x 2^(n+1),..., 2^m x 2^m.
+
+using Svg;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Linq;
+using System.Xml;
+
+namespace SvgToIco
+{
+
+class ConverterInputs
+{
+    public readonly SvgDocument SvgDocument;
+    public readonly string OutputFileName;
+
+    public ConverterInputs(
+        SvgDocument svgDocument,
+        string outputFileName)
+    {
+        SvgDocument = svgDocument;
+        OutputFileName = outputFileName;
+    }
+}
+
+class Program
+{
+    private const string ICO_EXTENSION = ".ico";
+
+    static void Main(string[] args)
+    {
+        Svg2IcoArguments parsedArgs;
+        if (!Svg2IcoArguments.TryParse(args, out parsedArgs))
+        {
+            return;
+        }
+
+        if (parsedArgs.ShowHelp)
+        {
+            ShowHelp();
+        }
+
+        var converterInputs = readSvgPaths(
+            parsedArgs.InputPaths,
+            parsedArgs.HasOutputDirectory ? parsedArgs.OutputDirectory : "",
+            parsedArgs.Recurse);
+        
+        foreach (var item in Enumerable.Select(converterInputs, (v, i) => new { v, i }))
+        {
+            var bitmaps = parsedArgs.Resolutions
+                .Select(res => DrawBitmap(item.v.SvgDocument, res.Width, res.Height))
+                .ToList();
+            WriteToIcoFile(item.v.OutputFileName, bitmaps);
+            Console.WriteLine(
+                " (" + (item.i + 1) + "/" + converterInputs.Count
+                + ") Icon written to: " + item.v.OutputFileName);
+        }
+    }
+
+    private static ICollection<ConverterInputs> readSvgPaths(
+        IEnumerable<string> inputPaths,
+        string outputDirectory,
+        bool recurse)
+    {
+        var results = new List<ConverterInputs>();
+        foreach (var path in inputPaths)
+        {
+            if (Directory.Exists(path))
+            {
+                var searchOption = recurse ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
+                foreach (
+                    var fileName
+                    in Directory.EnumerateFiles(path, "*.svg", searchOption))
+                {
+                    readSvgFile(fileName, outputDirectory, results);
+                }
+            } else
+            {
+                readSvgFile(path, outputDirectory, results);
+            }
+        }
+        return results;
+    }
+
+    private static void readSvgFile(
+        string fileName, string outputDirectory, ICollection<ConverterInputs> results)
+    {
+        try
+        {
+            var doc = SvgDocument.Open(fileName);
+            string outputFileName;
+            if (outputDirectory.Length > 0)
+            {
+                outputFileName = Path.Combine(
+                    outputDirectory, Path.GetFileNameWithoutExtension(fileName) + ICO_EXTENSION);
+            } else
+            {
+                outputFileName = Path.ChangeExtension(fileName, ICO_EXTENSION);
+            }
+            results.Add(new ConverterInputs(doc, outputFileName));
+        } catch (FileNotFoundException)
+        {
+            Console.WriteLine("File does not exist: " + fileName);
+        } catch (DirectoryNotFoundException)
+        {
+            Console.WriteLine("File does not exist: " + fileName);
+        } catch (PathTooLongException)
+        {
+            Console.WriteLine("File name is not valid: " + fileName);
+        } catch (IOException)
+        {
+            Console.WriteLine("File is in use by another process: " + fileName);
+        } catch (ArgumentException)
+        {
+            Console.WriteLine("File name is not valid: " + fileName);
+        } catch (NotSupportedException)
+        {
+            Console.WriteLine("File name is not valid: " + fileName);
+        } catch (UnauthorizedAccessException)
+        {
+            Console.WriteLine("Insufficient permission to access file: " + fileName);
+        } catch (XmlException ex)
+        {
+            Console.WriteLine("SVG file does not contain valid XML: " + fileName);
+        } catch (Exception ex)
+        {
+            Console.WriteLine(ex);
+        }
+    }
+    
+    static Bitmap DrawBitmap(SvgDocument doc, int width, int height)
+    {
+        doc.Width = width;
+        doc.Height = height;
+        var bmp = new Bitmap(width, height, PixelFormat.Format32bppArgb);
+        doc.Draw(bmp);
+        return bmp;
+    }
+
+    static void WriteToIcoFile(string fileName, IList<Bitmap> bitmaps)
+    {
+        using (var outputStream = new FileStream(fileName, FileMode.Create))
+        {
+            WriteIcoToStream(outputStream, bitmaps);
+        }
+    }
+
+    static void WriteIcoToStream(Stream stream, IList<Bitmap> bitmaps)
+    {
+        if (bitmaps.Any(bmp => bmp.Width> 256 || bmp.Height> 256))
+        {
+            throw new ArgumentException(
+                "ICO files cannot contain images with dimensions greater than 256x256 pixels");
+        }
+        bitmaps = bitmaps.Where(bmp => bmp.Width> 0 && bmp.Height> 0).ToList();
+
+        if (bitmaps.Count> ushort.MaxValue)
+        {
+            throw new ArgumentException(
+                "ICO files can only contain up to " + short.MaxValue + " images.");
+        }
+
+        IList<byte[]> pngImages = new List<byte[]>(bitmaps.Count);
+        foreach (var bmp in bitmaps)
+        {
+            using (var pngStream = new MemoryStream())
+            {
+                bmp.Save(pngStream, ImageFormat.Png);
+                pngImages.Add(pngStream.ToArray());
+            }
+        }
+        
+        var numImages = (ushort) bitmaps.Count;
+        WriteIcoMainHeader(stream, numImages);
+
+        uint headerSize = 6;
+        uint imageHeaderSize = 16;
+        uint offset = headerSize + numImages * imageHeaderSize;
+        foreach (var images in bitmaps.Zip(pngImages, Tuple.Create))
+        {
+            var bmp = images.Item1;
+            var png = images.Item2;
+            var imageSize = (uint) png.Length;
+            // The direct cast to a byte here is safe. We validate the image size above,
+            // so all images have a width/height in the range [1, 256]. Casting [1, 255]
+            // to a byte returns the same number, and casting 256 returns 0, which represents
+            // an image of size 256 bytes in the ICO format.
+            WriteIcoImageHeader(stream, (byte) bmp.Width, (byte) bmp.Height, imageSize, offset);
+            offset += imageSize;
+        }
+
+        foreach (var png in pngImages)
+        {
+            stream.Write(png, 0, png.Length);
+        }
+    }
+    
+    static void WriteIcoMainHeader(Stream stream, ushort numberImages)
+    {
+        var numberImagesLe = ToBytesLittleEndian(numberImages);
+        byte[] header = {
+            0, 0,
+            1, 0,
+            numberImagesLe[0], numberImagesLe[1]};
+        stream.Write(header, 0, header.Length);
+    }
+
+    static void WriteIcoImageHeader(
+        Stream stream,
+        byte imageWidth,
+        byte imageHeight,
+        uint imageSizeBytes,
+        uint imageOffsetBytes)
+    {
+        var sizeLe = ToBytesLittleEndian(imageSizeBytes);
+        var offsetLe = ToBytesLittleEndian(imageOffsetBytes);
+        byte[] header = {
+            imageWidth,
+            imageHeight,
+            0,
+            0,
+            0, 0,
+            32, 0,
+            sizeLe[0], sizeLe[1], sizeLe[2], sizeLe[3],
+            offsetLe[0], offsetLe[1], offsetLe[2], offsetLe[3]};
+        stream.Write(header, 0, header.Length);
+    }
+
+    static byte[] ReverseIfBigEndian(byte[] bytes)
+    {
+        if (!BitConverter.IsLittleEndian)
+        {
+            Array.Reverse(bytes);
+        }
+        return bytes;
+    }
+
+    static byte[] ToBytesLittleEndian(ushort value)
+    {
+        return ReverseIfBigEndian(BitConverter.GetBytes(value));
+    }
+
+    static byte[] ToBytesLittleEndian(uint value)
+    {
+        return ReverseIfBigEndian(BitConverter.GetBytes(value));
+    }
+
+    private static void ShowHelp()
+    {
+        Console.WriteLine(
+@"svg2ico[--help][--outdir<directory>][--recurse][--size<sizespec>]--[< path>...]
+
+# Options
+
+<files>
+
+    A list of files and directories in which to search for .svg files
+    to convert.
+
+<directory>
+
+    The directory in which to write.ico files.Writes them next to the
+    .svg image that generated them if not specified.
+
+<path>
+
+    An SVG file, or a directory in which to look for .svg files.
+
+<sizespec>
+
+    Resolution(s) to write in each.ico file.See below for the
+    format specification.
+
+-h, --help
+
+    Prints this text
+
+-o, --outdir
+
+    Specifies the output directory
+
+-r, --recurse
+
+    Recurse into any input directories when looking for .svg files.
+
+-s, --size
+
+    Specifies a resolution to place in each output.ico file. Use this
+    option multiple times to specify multiple resolutions.
+
+# Size Specification
+
+Square: <s>
+
+    Where `s` is a number in the range[0, 256]
+
+Rectangle: <w> x <h>
+
+    Where `w` and `h` are numbers in the range[0, 256]
+
+Square powers of two: <n>..<m>
+
+    Where `n` and `m` are numbers in the range[0, 8] and m >= n. Represents
+    images at resolutions of 2 ^ n x 2 ^ n, 2 ^ (n + 1) x 2 ^ (n + 1),..., 2 ^ m x 2 ^ m");
+
+    }
+}
+
+}

--- a/Svg2Ico/Program.cs
+++ b/Svg2Ico/Program.cs
@@ -62,28 +62,14 @@ using System.IO;
 using System.Linq;
 using System.Xml;
 
-namespace SvgToIco
+namespace Svg2Ico
 {
-
-class ConverterInputs
-{
-    public readonly SvgDocument SvgDocument;
-    public readonly string OutputFileName;
-
-    public ConverterInputs(
-        SvgDocument svgDocument,
-        string outputFileName)
-    {
-        SvgDocument = svgDocument;
-        OutputFileName = outputFileName;
-    }
-}
 
 class Program
 {
     private const string ICO_EXTENSION = ".ico";
 
-    static void Main(string[] args)
+    private static void Main(string[] args)
     {
         Svg2IcoArguments parsedArgs;
         if (!Svg2IcoArguments.TryParse(args, out parsedArgs))
@@ -175,7 +161,7 @@ class Program
         } catch (UnauthorizedAccessException)
         {
             Console.WriteLine("Insufficient permission to access file: " + fileName);
-        } catch (XmlException ex)
+        } catch (XmlException)
         {
             Console.WriteLine("SVG file does not contain valid XML: " + fileName);
         } catch (Exception ex)
@@ -184,7 +170,7 @@ class Program
         }
     }
     
-    static Bitmap DrawBitmap(SvgDocument doc, int width, int height)
+    private static Bitmap DrawBitmap(SvgDocument doc, int width, int height)
     {
         doc.Width = width;
         doc.Height = height;
@@ -193,7 +179,7 @@ class Program
         return bmp;
     }
 
-    static void WriteToIcoFile(string fileName, IList<Bitmap> bitmaps)
+    private static void WriteToIcoFile(string fileName, IList<Bitmap> bitmaps)
     {
         using (var outputStream = new FileStream(fileName, FileMode.Create))
         {
@@ -201,7 +187,7 @@ class Program
         }
     }
 
-    static void WriteIcoToStream(Stream stream, IList<Bitmap> bitmaps)
+    private static void WriteIcoToStream(Stream stream, IList<Bitmap> bitmaps)
     {
         if (bitmaps.Any(bmp => bmp.Width> 256 || bmp.Height> 256))
         {
@@ -251,7 +237,7 @@ class Program
         }
     }
     
-    static void WriteIcoMainHeader(Stream stream, ushort numberImages)
+    private static void WriteIcoMainHeader(Stream stream, ushort numberImages)
     {
         var numberImagesLe = ToBytesLittleEndian(numberImages);
         byte[] header = {
@@ -261,7 +247,7 @@ class Program
         stream.Write(header, 0, header.Length);
     }
 
-    static void WriteIcoImageHeader(
+    private static void WriteIcoImageHeader(
         Stream stream,
         byte imageWidth,
         byte imageHeight,
@@ -282,7 +268,7 @@ class Program
         stream.Write(header, 0, header.Length);
     }
 
-    static byte[] ReverseIfBigEndian(byte[] bytes)
+    private static byte[] ReverseIfBigEndian(byte[] bytes)
     {
         if (!BitConverter.IsLittleEndian)
         {
@@ -291,12 +277,12 @@ class Program
         return bytes;
     }
 
-    static byte[] ToBytesLittleEndian(ushort value)
+    private static byte[] ToBytesLittleEndian(ushort value)
     {
         return ReverseIfBigEndian(BitConverter.GetBytes(value));
     }
 
-    static byte[] ToBytesLittleEndian(uint value)
+    private static byte[] ToBytesLittleEndian(uint value)
     {
         return ReverseIfBigEndian(BitConverter.GetBytes(value));
     }
@@ -359,6 +345,19 @@ Square powers of two: <n>..<m>
     Where `n` and `m` are numbers in the range[0, 8] and m >= n. Represents
     images at resolutions of 2 ^ n x 2 ^ n, 2 ^ (n + 1) x 2 ^ (n + 1),..., 2 ^ m x 2 ^ m");
 
+    }
+
+    private class ConverterInputs
+    {
+        public readonly SvgDocument SvgDocument;
+        public readonly string OutputFileName;
+
+        public ConverterInputs(
+            SvgDocument svgDocument, string outputFileName)
+        {
+            SvgDocument = svgDocument;
+            OutputFileName = outputFileName;
+        }
     }
 }
 

--- a/Svg2Ico/Properties/AssemblyInfo.cs
+++ b/Svg2Ico/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Svg2Ico")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Svg2Ico")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("5e208507-18aa-4520-92fe-f8799dab76a8")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Svg2Ico/Svg2Ico.csproj
+++ b/Svg2Ico/Svg2Ico.csproj
@@ -50,6 +50,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ArgumentParser.cs" />
+    <Compile Include="IcoResolution.cs" />
+    <Compile Include="IcoSize.cs" />
     <Compile Include="Mono.Options\Options.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Svg2Ico/Svg2Ico.csproj
+++ b/Svg2Ico/Svg2Ico.csproj
@@ -1,0 +1,69 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{5E208507-18AA-4520-92FE-F8799DAB76A8}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Svg2Ico</RootNamespace>
+    <AssemblyName>Svg2Ico</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Svg, Version=2.1.0.28187, Culture=neutral, PublicKeyToken=12a0bac221edeae2, processorArchitecture=MSIL">
+      <HintPath>..\packages\Svg.2.1.0\lib\Svg.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ArgumentParser.cs" />
+    <Compile Include="Mono.Options\Options.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Svg2Ico/packages.config
+++ b/Svg2Ico/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Mono.Options" version="1.1" targetFramework="net452" />
+  <package id="Svg" version="2.1.0" targetFramework="net452" />
+</packages>


### PR DESCRIPTION
WPF can't handle SVG files directly, but they are really nice for constructing icons. The Svg2Ico project is command line based, so it can be added to the build process to generate the icons automatically. This way, there is no need to put the .ico files in source control, and we have an easy way to keep the icons up-to-date.
